### PR TITLE
Fixing folder with misp.local.key

### DIFF
--- a/docs/xINSTALL.centos7.md
+++ b/docs/xINSTALL.centos7.md
@@ -332,7 +332,7 @@ echo $OPENSSL_CN
 sudo systemctl start httpd.service
 sudo openssl dhparam -out /etc/pki/tls/certs/dhparam.pem 4096
 sudo openssl genrsa -des3 -passout pass:x -out /tmp/misp.local.key 4096
-sudo openssl rsa -passin pass:x -in /tmp/misp.local.key -out /etc/pki/tls/certs/misp.local.key
+sudo openssl rsa -passin pass:x -in /tmp/misp.local.key -out /etc/pki/tls/private/misp.local.key
 sudo rm /tmp/misp.local.key
 sudo openssl req -new -subj "/C=${OPENSSL_C}/ST=${OPENSSL_ST}/L=${OPENSSL_L}/O=${OPENSSL_O}/OU=${OPENSSL_OU}/CN=${OPENSSL_CN}/emailAddress=${OPENSSL_EMAILADDRESS}" -key /etc/pki/tls/certs/misp.local.key -out /etc/pki/tls/certs/misp.local.csr
 sudo openssl x509 -req -days 365 -in /etc/pki/tls/certs/misp.local.csr -signkey /etc/pki/tls/private/misp.local.key -out /etc/pki/tls/certs/misp.local.crt


### PR DESCRIPTION
### Work environment

| Questions                 | Answers
|---------------------------|--------------------
| Type of issue             | Documentation Update
| OS version (server)       | CentOS
| OS version (client)       | Ubuntu, ...
| PHP version               | 7.1
| MISP version / git hash   | 2.4
| Browser                   | If applicable

### Expected behavior
Follow procedures to install, with no errors.

### Actual behavior
Error to create ssl keys, while following procedures.
The steps to create openssl private keys on line 335 point to file in /etc/pki/tls/certs/misp.local.key, while later in line 338 it looks for file in /etc/pki/tls/certs/misp.local.key.


### Steps to reproduce the behavior


### Logs, screenshots, configuration dump, ...

